### PR TITLE
Add space after =

### DIFF
--- a/DecryptEngine.py
+++ b/DecryptEngine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-BLOCKSIZE =16 
+BLOCKSIZE = 16 
 
 class DecryptEngine():
 


### PR DESCRIPTION
An important stylish space was missing after the = operator.